### PR TITLE
added react-native scripts 1.12.0 - this added an 's' option whith 'y…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "jest-expo": "26.0.0",
-    "react-native-scripts": "1.13.1",
+    "react-native-scripts": "1.12.0",
     "react-test-renderer": "16.3.0-alpha.1"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5825,9 +5825,9 @@ react-native-safe-module@^1.1.0:
   dependencies:
     dedent "^0.6.0"
 
-react-native-scripts@1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/react-native-scripts/-/react-native-scripts-1.13.1.tgz#26708148ca7f0507a30fc2d1484e0c4561cafd2c"
+react-native-scripts@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/react-native-scripts/-/react-native-scripts-1.12.0.tgz#acbdb8bc8f7668e2dad15223c8777b99ba481966"
   dependencies:
     "@expo/bunyan" "1.8.10"
     babel-runtime "^6.9.2"
@@ -5843,7 +5843,7 @@ react-native-scripts@1.13.1:
     progress "^2.0.0"
     qrcode-terminal "^0.11.0"
     rimraf "^2.6.1"
-    xdl "48.1.4"
+    xdl "48.1.0"
 
 react-native-svg@6.2.2:
   version "6.2.2"
@@ -7441,9 +7441,9 @@ xcode@^0.9.1:
     simple-plist "^0.2.1"
     uuid "3.0.1"
 
-xdl@48.1.4:
-  version "48.1.4"
-  resolved "https://registry.yarnpkg.com/xdl/-/xdl-48.1.4.tgz#95e75ab3537034508e5d0e1cb476c8c661df43b4"
+xdl@48.1.0:
+  version "48.1.0"
+  resolved "https://registry.yarnpkg.com/xdl/-/xdl-48.1.0.tgz#eeb03d6938cfb168524a0fe0191db861669fce11"
   dependencies:
     "@expo/bunyan" "^1.8.10"
     "@expo/json-file" "^5.3.0"


### PR DESCRIPTION
…arn start' command - this should fix the problem with the missing QR scanner